### PR TITLE
get rid of visual basic 🥲🥲 (and other things)

### DIFF
--- a/ideas/rules.md
+++ b/ideas/rules.md
@@ -9,8 +9,6 @@ Repositories made in the club should be under the organization.
 - C#
 - Lua (something to learn)
 - Java
-- Javascript
+- Javascript / Typescript (something to learn)
 - Python
 - Rust (we're gonna need to find someone who knows it well)
-- Typescript (something to learn)
-- Visual Basic


### PR DESCRIPTION
just do not use visual basic -> bad
javascript/typescript sorta go hand in hand since typescript is just a superset of javascript, so it can be introduced after covering the meat of the javasdcript content